### PR TITLE
Fix compilation parsing error in chat page

### DIFF
--- a/app/(dashboard)/chat/page_old.tsx
+++ b/app/(dashboard)/chat/page_old.tsx
@@ -549,6 +549,5 @@ export default function ChatPage() {
           </div>
         </div>
       </div>
-    </div>
   )
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove an extra `</div>` tag in `page_old.tsx` to fix a parsing error during compilation.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The extra `</div>` tag at line 552 caused an imbalance in the HTML structure, leading the TypeScript/JSX parser to report a ')' expected error and fail the build. Removing it resolves the compilation issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b8d2e54-1da8-476c-8fce-1a36c80b8752">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b8d2e54-1da8-476c-8fce-1a36c80b8752">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

